### PR TITLE
Installable as a rock

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -16,20 +16,15 @@ function gui.command()
     -- (normally not necessary, but now LuaRocks already loaded LuaSocket)
     package.loaded["socket.http"] = nil
 
+    local datafile = require "datafile"
     local xavante = require "xavante"
+    local redirect = require "xavante.redirecthandler"
     local filehandler = require "xavante.filehandler"
     local cgiluahandler = require "xavante.cgiluahandler"
-    local redirect = require "xavante.redirecthandler"
-
-    --local datafile = require("luarocks_gui.gui")
-    --local datafile = require("datafile")
-
-    --local s = assert(datafile.path("gui/0.0.1-1/pages/index.lp", "r"))
-    --local s = assert(datafile.path("pages/index.lp", "r"))
 
     -- Define here where Xavante HTTP documents scripts are located
-    local webDir = "pages"
-
+    local path = datafile.path("pages/index.lp", "r")
+    local webDir = path:sub(1, -1 - #("/index.lp"))
 
     local simplerules = {
 

--- a/gui.lua
+++ b/gui.lua
@@ -11,16 +11,21 @@ You can view the gui by visting: http://localhost:8080/ from your web browser.
 
 function gui.command()
 
+    local port = 8080
+
     -- Copas needs to patch "socket.http" to use the copas sockets. Hence
     -- it requires `socket.http` to not have been loaded. So let's clear it.
     -- (normally not necessary, but now LuaRocks already loaded LuaSocket)
     package.loaded["socket.http"] = nil
 
+    local fs = require "luarocks.fs"
+    local copas = require "copas"
     local datafile = require "datafile"
     local xavante = require "xavante"
     local redirect = require "xavante.redirecthandler"
     local filehandler = require "xavante.filehandler"
     local cgiluahandler = require "xavante.cgiluahandler"
+
 
     -- Define here where Xavante HTTP documents scripts are located
     local path = datafile.path("pages/index.lp", "r")
@@ -46,13 +51,26 @@ function gui.command()
         },
     }
 
+
+    -- create the webserver
     xavante.HTTP{
-        server = {host = "*", port = 8080},
+        server = {host = "*", port = port},
 
         defaultHost = {
           rules = simplerules
         }
     }
+
+    -- schedule a task to open the webbrowser
+    copas.addthread(function()
+        copas.sleep(0.1)  -- wait for a tiny bit to allow Xavante to start
+        print("Serving the LuaRocks gui on 'http://localhost:" .. port .. "'.")
+        local ok = fs.browser("http://localhost:" .. port)
+        if not ok then
+          print("WARNING: Failed to open the browser, please visit the url manually.")
+        end
+    end)
+
     xavante.start()
 end
 

--- a/gui.lua
+++ b/gui.lua
@@ -1,12 +1,5 @@
-local xavante = require "xavante"
-local filehandler = require "xavante.filehandler"
-local cgiluahandler = require "xavante.cgiluahandler"
-local redirect = require "xavante.redirecthandler"
-
---local datafile = require("luarocks_gui.gui")
---local datafile = require("datafile")
-
 local gui = {}
+
 gui.help_summary = "Starts the LuaRocks web gui server"
 gui.help_arguments = nil
 gui.help = [[
@@ -17,10 +10,22 @@ You can view the gui by visting: http://localhost:8080/ from your web browser.
 
 
 function gui.command()
+
+    -- Copas needs to patch "socket.http" to use the copas sockets. Hence
+    -- it requires `socket.http` to not have been loaded. So let's clear it.
+    -- (normally not necessary, but now LuaRocks already loaded LuaSocket)
+    package.loaded["socket.http"] = nil
+
+    local xavante = require "xavante"
+    local filehandler = require "xavante.filehandler"
+    local cgiluahandler = require "xavante.cgiluahandler"
+    local redirect = require "xavante.redirecthandler"
+
+    --local datafile = require("luarocks_gui.gui")
+    --local datafile = require("datafile")
+
     --local s = assert(datafile.path("gui/0.0.1-1/pages/index.lp", "r"))
     --local s = assert(datafile.path("pages/index.lp", "r"))
-
-    print("ayy lmao gui")
 
     -- Define here where Xavante HTTP documents scripts are located
     local webDir = "pages"

--- a/gui.lua
+++ b/gui.lua
@@ -1,15 +1,23 @@
-gui1 = {}
-
-local xavante = require "xavante" 
+local xavante = require "xavante"
 local filehandler = require "xavante.filehandler"
 local cgiluahandler = require "xavante.cgiluahandler"
 local redirect = require "xavante.redirecthandler"
 
---local datafile = require("luarocks_gui.gui1")
+--local datafile = require("luarocks_gui.gui")
 --local datafile = require("datafile")
 
-function gui1.command()
-    --local s = assert(datafile.path("gui1/0.0.1-1/pages/index.lp", "r"))
+local gui = {}
+gui.help_summary = "Starts the LuaRocks web gui server"
+gui.help_arguments = nil
+gui.help = [[
+This starts a local webserver to access the LuaRocks web gui.
+
+You can view the gui by visting: http://localhost:8080/ from your web browser.
+]]
+
+
+function gui.command()
+    --local s = assert(datafile.path("gui/0.0.1-1/pages/index.lp", "r"))
     --local s = assert(datafile.path("pages/index.lp", "r"))
 
     print("ayy lmao gui")
@@ -24,23 +32,23 @@ function gui1.command()
             match = "^[^%./]*/$",
             with = redirect,
             params = {"index.lp"}
-          }, 
+          },
 
         { -- cgiluahandler example
           match = {"%.lp$", "%.lp/.*$", "%.lua$", "%.lua/.*$" },
           with = cgiluahandler.makeHandler (webDir)
         },
-        
+
         { -- filehandler example
           match = ".",
           with = filehandler,
           params = {baseDir = webDir}
         },
-    } 
+    }
 
     xavante.HTTP{
         server = {host = "*", port = 8080},
-        
+
         defaultHost = {
           rules = simplerules
         }
@@ -48,6 +56,4 @@ function gui1.command()
     xavante.start()
 end
 
---gui1.command()
-
-return gui1
+return gui

--- a/luarocks-gui-0.0.0-1.rockspec
+++ b/luarocks-gui-0.0.0-1.rockspec
@@ -10,7 +10,8 @@ description = {
 dependencies = {
    "lua >= 5.1, < 5.4 ",
    "xavante",
-   "wsapi-xavante"
+   "wsapi-xavante",
+   "cgilua",
 }
 
 source = {

--- a/luarocks-gui-0.0.0-1.rockspec
+++ b/luarocks-gui-0.0.0-1.rockspec
@@ -12,6 +12,7 @@ dependencies = {
    "xavante",
    "wsapi-xavante",
    "cgilua",
+   "datafile",
 }
 
 source = {

--- a/luarocks-gui-0.0.0-1.rockspec
+++ b/luarocks-gui-0.0.0-1.rockspec
@@ -2,13 +2,15 @@ package = "luarocks-gui"
 version = "0.0.0-1"
 
 description = {
-   summary = "GUI module for Lua 5.x",
-   license = "",
+   summary = "GUI module for LuaRocks 3.x",
+   license = "MIT",
    homepage = "https://github.com/jiteshpabla/luarocks-gui",
 }
 
 dependencies = {
-   "lua >= 5.0, < 5.4 "
+   "lua >= 5.1, < 5.4 ",
+   "xavante",
+   "wsapi-xavante"
 }
 
 source = {
@@ -18,8 +20,7 @@ source = {
 build = {
    type = "builtin",
    modules = {
-      ['luarocks_gui.gui1'] = "gui1.lua",
+      ['luarocks.cmd.external.gui'] = "gui.lua",
    },
    copy_directories = { "pages" }
 }
-


### PR DESCRIPTION
This PR updates the module to be a proper rock.

- Made the module a proper rock by updating the rockspec, and installing in the right place, with the right name
- The rock installs itself as a new command for LuaRocks 3 (start it with `luarocks gui`)
- Updated dependencies in the rockspec (datafile, xavante, etc)
- Fixed the `datafile` usage, it no longer relies on the local repository files, but now uses the files installed along with the rock

**Notes:**

- still shows the problems with LuaRocks 3 (indexing `arg`) to be fixed in LuaRocks
- requires some bugfixes to datafile, see https://github.com/hishamhm/datafile/pull/22
- requires the `luarocks-api` branch of the LuaRocks repo

Ping @hishamhm @jiteshpabla 